### PR TITLE
Split me action into two methods

### DIFF
--- a/api_yamdb/api/views.py
+++ b/api_yamdb/api/views.py
@@ -90,7 +90,6 @@ class UserViewSet(ModelViewSet):
 
     @action(
         detail=False,
-        methods=('get',),
         permission_classes=(IsAuthenticated,),
     )
     def me(self, request):


### PR DESCRIPTION
Нашёл способ разбить доп. эндпоинт /users/me на два метода через какую-то [жуткую магию с декораторами](https://www.django-rest-framework.org/api-guide/viewsets/#routing-additional-http-methods-for-extra-actions). Все тесты по-прежнему проходят.