### PR TITLE
Minor fixes in text and class names

### DIFF
--- a/api_yamdb/api/serializers.py
+++ b/api_yamdb/api/serializers.py
@@ -60,8 +60,8 @@ class GenreSerializer(serializers.ModelSerializer):
         model = Genre
 
 
-class TitlePostSerializer(serializers.ModelSerializer):
-    """Сериализатор названия произведения для POST и PATCH методов."""
+class TitleWriteSerializer(serializers.ModelSerializer):
+    """Сериализатор произведения для записи."""
 
     genre = serializers.SlugRelatedField(
         queryset=Genre.objects.all(),
@@ -82,8 +82,8 @@ class TitlePostSerializer(serializers.ModelSerializer):
     #     return obj.reviews.aggregate(rating=Avg('score'))['rating']
 
 
-class TitleGetSerializer(serializers.ModelSerializer):
-    """Сериализатор названия произведения для GET методов."""
+class TitleReadSerializer(serializers.ModelSerializer):
+    """Сериализатор произведения для чтения."""
 
     genre = GenreSerializer(read_only=True, many=True)
     category = CategorySerializer(read_only=True)

--- a/api_yamdb/api/views.py
+++ b/api_yamdb/api/views.py
@@ -29,8 +29,8 @@ from .serializers import (
     CategorySerializer,
     GenreSerializer,
     SignUpSerializer,
-    TitleGetSerializer,
-    TitlePostSerializer,
+    TitleReadSerializer,
+    TitleWriteSerializer,
     TokenSerializer,
     UserMeSerializer,
     UserSerializer,
@@ -126,8 +126,8 @@ class TitleViewSet(ModelViewSet):
 
     def get_serializer_class(self):
         if self.request.method in ('POST', 'PATCH'):
-            return TitlePostSerializer
-        return TitleGetSerializer
+            return TitleWriteSerializer
+        return TitleReadSerializer
 
 
 class GenreViewSet(

--- a/api_yamdb/reviews/models.py
+++ b/api_yamdb/reviews/models.py
@@ -58,11 +58,6 @@ class Genre(models.Model):
 
     class Meta:
         ordering = ('name',)
-        verbose_name = 'Категория'
-        verbose_name_plural = 'Категории'
-
-    class Meta:
-        ordering = ('name',)
         verbose_name = 'Жанр'
         verbose_name_plural = 'Жанры'
 
@@ -86,7 +81,7 @@ class Category(models.Model):
 
 
 class Title(models.Model):
-    """Модель названия произведения"""
+    """Модель произведения"""
 
     name = models.CharField(max_length=256, verbose_name='Название')
     year = models.IntegerField(
@@ -97,7 +92,7 @@ class Title(models.Model):
         Genre,
         related_name='titles',
         verbose_name='Slug жанра',
-        help_text='Жанр, к которому будет относиться произведение',
+        help_text='Жанры произведения',
     )
     category = models.ForeignKey(
         Category,
@@ -105,7 +100,7 @@ class Title(models.Model):
         null=True,
         related_name='titles',
         verbose_name='Slug категории',
-        help_text='Категория, к которому будет относиться произведение',
+        help_text='Категория произведения',
     )
 
     class Meta:


### PR DESCRIPTION
Перечитывал код и заметил, что в модели `Genre` есть сдублированный класс Meta. Заодно немного подправил докстринги и дал сериализаторам для произведений более подходящие названия.